### PR TITLE
enable required build flag for 4.5 models

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -69,7 +69,7 @@ else
   opt_var.add_cmake_defines({'WITH_LAYER_input': true})
   opt_var.add_cmake_defines({'WITH_LAYER_log': false})
   opt_var.add_cmake_defines({'WITH_LAYER_lrn': false})
-  opt_var.add_cmake_defines({'WITH_LAYER_memorydata': false})
+  opt_var.add_cmake_defines({'WITH_LAYER_memorydata': true})
   opt_var.add_cmake_defines({'WITH_LAYER_mvn': false})
   opt_var.add_cmake_defines({'WITH_LAYER_pooling': true})
   opt_var.add_cmake_defines({'WITH_LAYER_power': false})


### PR DESCRIPTION
4.5 models won't run without memorydata enabled

After changing this both 4.5 models do run however the output images appear visually broken, the videos appear very shaky.

compiled on windows 